### PR TITLE
fix: timezone

### DIFF
--- a/electron/service/infoFile/service.ts
+++ b/electron/service/infoFile/service.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import * as datefns from 'date-fns';
-import * as datefnsTz from 'date-fns-tz';
 import * as log from 'electron-log';
 import * as neverthrow from 'neverthrow';
 import * as fs from '../../lib/wrappedFs';
@@ -47,11 +46,9 @@ const getToCreateMap = async (
       );
       // date は local time なので utc に変換
       // timezone は実行環境から取得する
-      const { timeZone } = Intl.DateTimeFormat().resolvedOptions();
-      log.info(`timeZone: ${timeZone}`);
-      const localDateString = datefns.format(date, 'yyyy-MM-dd HH:mm:ss');
-      log.info(`localDateString: ${localDateString}`);
-      const utcDate = datefnsTz.zonedTimeToUtc(localDateString, timeZone);
+      const diffMinsToUtc = date.getTimezoneOffset();
+      log.info(`diffMinsToUtc: ${diffMinsToUtc}`);
+      const utcDate = datefns.addMinutes(date, diffMinsToUtc);
       log.info(`date: ${date} -> utcDate: ${utcDate}`);
       log.info(
         `date: ${datefns.format(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能変更**
  - ローカル日付をUTCに変換するロジックを更新しました。以前は`Intl.DateTimeFormat().resolvedOptions()`を使用していましたが、現在は`date.getTimezoneOffset()`を利用しています。

- **削除された機能**
  - `date-fns-tz`のインポートを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->