### PR TITLE
dev

### DIFF
--- a/electron/api.ts
+++ b/electron/api.ts
@@ -17,6 +17,7 @@ const t = initTRPC.create({
 });
 
 const logError = (err: Error | string) => {
+  ee.emit('toast', err);
   let error: Error;
   if (typeof err === 'string') {
     error = new Error(`TRPCErrorLogger: ${err}`);
@@ -194,6 +195,18 @@ export const router = t.router({
     }),
   openPathOnExplorer: procedure.input(z.string()).mutation(async (ctx) => {
     const result = await service.openPathOnExplorer(ctx.input);
+    return result.match(
+      () => {
+        return true;
+      },
+      (error) => {
+        logError(error);
+        return false;
+      },
+    );
+  }),
+  openElectronLogOnExplorer: procedure.mutation(async () => {
+    const result = await service.openElectronLogOnExplorer();
     return result.match(
       () => {
         return true;

--- a/electron/service.ts
+++ b/electron/service.ts
@@ -257,6 +257,7 @@ const clearStoredSetting = (
 };
 
 const openPathOnExplorer = (filePath: string) => {
+  log.debug(`openPathOnExplorer ${filePath}`);
   return utilsService.openPathInExplorer(filePath);
 };
 

--- a/electron/service.ts
+++ b/electron/service.ts
@@ -260,6 +260,12 @@ const openPathOnExplorer = (filePath: string) => {
   return utilsService.openPathInExplorer(filePath);
 };
 
+const openElectronLogOnExplorer = async () => {
+  const electronLogPath = log.transports.file.getFile().path;
+  log.debug(`electronLogPath ${electronLogPath}`);
+  return utilsService.openPathInExplorer(electronLogPath);
+};
+
 const openDirOnExplorer = (dirPath: string) => {
   const dir = path.dirname(dirPath);
   return utilsService.openPathInExplorer(dir);
@@ -410,6 +416,7 @@ export {
   clearAllStoredSettings,
   clearStoredSetting,
   openPathOnExplorer,
+  openElectronLogOnExplorer,
   openDirOnExplorer,
   getVRChatPhotoItemDataListByYearMonth,
   getVRChatPhotoWithWorldIdAndDate,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "4.35.3",
     "@trpc/client": "^10.43.0",
     "@trpc/react-query": "^10.43.0",

--- a/src/components/JoinInfoPreview.tsx
+++ b/src/components/JoinInfoPreview.tsx
@@ -1,4 +1,4 @@
-import Photo from '@/components/ui/Photo';
+import VrcPhoto from '@/components/ui/VrcPhoto';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { trpcReact } from '@/trpc';
@@ -12,6 +12,8 @@ export function JoinInfoPreview({ className }: Props) {
   const infoMap = data?.data;
   const error = data?.error;
 
+  const openPhotoPathMutation = trpcReact.openPathOnExplorer.useMutation();
+
   const PhotoList = (
     tookPhotoList: {
       photoPath: string;
@@ -20,7 +22,8 @@ export function JoinInfoPreview({ className }: Props) {
   ) => {
     return tookPhotoList.map((photo) => {
       return (
-        <Photo
+        <VrcPhoto
+          onClickPhoto={() => openPhotoPathMutation.mutate(photo.photoPath)}
           photoPath={photo.photoPath}
           className="w-32"
           key={photo.tookDatetime}

--- a/src/components/ui/VrcPhoto.tsx
+++ b/src/components/ui/VrcPhoto.tsx
@@ -1,0 +1,53 @@
+import { trpcReact } from '@/trpc';
+import { Ban, Loader } from 'lucide-react';
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './tooltip';
+
+export interface PhotoProps extends React.HTMLAttributes<HTMLDivElement> {
+  photoPath: string;
+  onClickPhoto: (photoPath: string) => void;
+}
+
+function VrcPhoto({ photoPath, ...props }: PhotoProps) {
+  const query = trpcReact.getVRChatPhotoItemData.useQuery(photoPath);
+  const { data, isLoading } = query;
+
+  if (isLoading) {
+    return <Loader className="w-8 h-8" />;
+  }
+  if (!data) {
+    return <Ban className="w-8 h-8" />;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <button type="button" onClick={() => props.onClickPhoto?.(photoPath)}>
+            <div
+              {...props}
+              className={cn(
+                'flex flex-col items-center justify-center w-full h-full',
+                props.className,
+              )}
+            >
+              <img src={data} className="w-full h-full" alt="" />
+            </div>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Open</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default VrcPhoto;

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/page/PhotoList.tsx
+++ b/src/page/PhotoList.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react';
 
 import Sidebar from '@/components/SideBar';
 import Photo from '@/components/ui/Photo';
+import VrcPhoto from '@/components/ui/VrcPhoto';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ROUTER_PATHS } from '@/constants';
@@ -127,6 +128,8 @@ function PhotoList() {
     [sortedYearMonthList],
   );
 
+  const openPhotoPathMutation = trpcReact.openPathOnExplorer.useMutation();
+
   return (
     <div className="h-full grid grid-cols-5 overflow-hidden">
       <ScrollArea className="grow">
@@ -186,7 +189,12 @@ function PhotoList() {
                 {sortedPhotoItemList?.map((item) => {
                   const content =
                     item.type === 'PHOTO' ? (
-                      <Photo photoPath={item.path} />
+                      <VrcPhoto
+                        photoPath={item.path}
+                        onClickPhoto={() => {
+                          openPhotoPathMutation.mutate(item.path);
+                        }}
+                      />
                     ) : (
                       <Photo photoPath={item.path} />
                     );

--- a/src/page/Setting.tsx
+++ b/src/page/Setting.tsx
@@ -19,6 +19,9 @@ function Setting() {
     return <Check size={24} className="text-green-500" />;
   };
 
+  const openAppLogFileMutation =
+    trpcReact.openElectronLogOnExplorer.useMutation();
+
   return (
     <div className="flex-auto h-full">
       <div className="flex flex-col justify-center items-center h-full space-y-8">
@@ -57,12 +60,14 @@ function Setting() {
               </Link>
             </div>
           </div>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={() => openAppLogFileMutation.mutate()}
+          >
+            アプリログを開く
+          </Button>
         </div>
-
-        {/* ファイル生成画面に移動するボタン */}
-        <Link to={ROUTER_PATHS.CREATE_JOIN_INFO}>
-          <Button variant="outline">完了</Button>
-        </Link>
       </div>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,6 +684,33 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz"
   integrity sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==
 
+"@floating-ui/core@^1.4.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.2.tgz#53a0f7a98c550e63134d504f26804f6b83dbc071"
+  integrity sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/dom@^1.5.1":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.4.tgz#b076fafbdfeb881e1d86ae748b7ff95150e9f3ec"
+  integrity sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==
+  dependencies:
+    "@floating-ui/dom" "^1.5.1"
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
+  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+
 "@heroicons/react@^2.0.18":
   version "2.0.18"
   resolved "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz"
@@ -1064,6 +1091,14 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-slot" "1.0.2"
 
+"@radix-ui/react-arrow@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
+  integrity sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/react-collection@1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz"
@@ -1154,6 +1189,23 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
 
+"@radix-ui/react-popper@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.3.tgz#24c03f527e7ac348fabf18c89795d85d21b00b42"
+  integrity sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
 "@radix-ui/react-portal@1.0.4":
   version "1.0.4"
   resolved "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz"
@@ -1243,6 +1295,25 @@
     "@radix-ui/react-roving-focus" "1.0.4"
     "@radix-ui/react-use-controllable-state" "1.0.1"
 
+"@radix-ui/react-tooltip@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz#8f55070f852e7e7450cc1d9210b793d2e5a7686e"
+  integrity sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz"
@@ -1270,6 +1341,37 @@
   version "1.0.1"
   resolved "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz"
   integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz#fde50b3bb9fd08f4a1cd204572e5943c244fcec2"
+  integrity sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-use-size@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz#1c5f5fea940a7d7ade77694bb98116fb49f870b2"
+  integrity sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-visually-hidden@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz#51aed9dd0fe5abcad7dee2a234ad36106a6984ac"
+  integrity sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.1.tgz#bf8e7d947671996da2e30f4904ece343bc4a883f"
+  integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
 


### PR DESCRIPTION
- feat: app log を直接開くボタンを設置
- chore: npx shadcn-ui@latest add tooltip
- feat: phpto click で写真を開く


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Electronログファイルをエクスプローラーで開く機能を追加しました。
  - VRChatの写真を表示する新しいコンポーネント`VrcPhoto`を追加しました。
  - 写真リストページに`VrcPhoto`コンポーネントを使用するよう変更しました。

- **機能改善**
  - エラー発生時にトースト通知を表示するように`logError`関数を改善しました。

- **バグ修正**
  - 写真をクリックした際に正しくパスを開くように修正しました。

- **ドキュメント**
  - ツールチップ関連のコンポーネントを新たに追加しました。

- **スタイル**
  - 検索バーと`VrcPhoto`コンポーネントにスタイルを適用しました。

- **その他の変更**
  - 設定ページからファイル作成画面へのナビゲーションを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->