### PR TITLE
dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,5 +8,6 @@
       "label": "desktop"
     }
   },
-  "runArgs": ["--shm-size=2g"]
+  "runArgs": ["--shm-size=2g"],
+  "postCreateCommand": "npm i -g @antfu/ni"
 }

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,7 @@
     "formatter": {
       "quoteStyle": "single"
     },
-    "globals": ["it", "describe", "expect"]
+    "globals": ["it", "describe", "expect", "jest"]
   },
   "files": {
     "ignore": ["**/node_modules/**", "**/dist/**", "**/main/**", "**/out/**"]

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,8 @@
       "recommended": true,
       "correctness": {
         "noUndeclaredVariables": "error",
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "useExhaustiveDependencies": "off"
       }
     }
   },

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,7 @@
     "formatter": {
       "quoteStyle": "single"
     },
-    "globals": ["it", "describe", "expect", "jest"]
+    "globals": ["it", "describe", "expect", "jest", "beforeEach"]
   },
   "files": {
     "ignore": ["**/node_modules/**", "**/dist/**", "**/main/**", "**/out/**"]

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -8,7 +8,8 @@ import z from 'zod';
 import path from 'path';
 import * as log from 'electron-log';
 import { Result } from 'neverthrow';
-import * as service from './service';
+import { getService } from './service';
+import { getSettingStore } from './settingStore';
 
 const ee = new EventEmitter();
 
@@ -50,6 +51,8 @@ const errorHandler = t.middleware(async (opts) => {
 const { procedure: p } = t;
 
 const procedure = p.use(errorHandler);
+
+const service = getService(getSettingStore('v0-settings'));
 
 export const router = t.router({
   // sample

--- a/electron/controller.ts
+++ b/electron/controller.ts
@@ -1,45 +1,60 @@
 import { dialog } from 'electron';
 import * as neverthrow from 'neverthrow';
-import * as settingStore from './settingStore';
+import { getSettingStore } from './settingStore';
 
-export const handleOpenDialogAndSetLogFilesDir = async (): Promise<
-  neverthrow.Result<'canceled' | 'dir_path_saved', Error>
-> => {
-  try {
-    const result = await dialog.showOpenDialog({
-      properties: ['openDirectory'],
-    });
-    if (result.canceled) {
-      return neverthrow.ok('canceled' as const);
+const handleOpenDialogAndSetLogFilesDir =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<
+    neverthrow.Result<'canceled' | 'dir_path_saved', Error>
+  > => {
+    try {
+      const result = await dialog.showOpenDialog({
+        properties: ['openDirectory'],
+      });
+      if (result.canceled) {
+        return neverthrow.ok('canceled' as const);
+      }
+      const dirPath = result.filePaths[0];
+      settingStore.setLogFilesDir(dirPath);
+      return neverthrow.ok('dir_path_saved' as const);
+    } catch (err) {
+      if (err instanceof Error) {
+        return neverthrow.err(err);
+      }
+      throw err;
     }
-    const dirPath = result.filePaths[0];
-    settingStore.setLogFilesDir(dirPath);
-    return neverthrow.ok('dir_path_saved' as const);
-  } catch (err) {
-    if (err instanceof Error) {
-      return neverthrow.err(err);
-    }
-    throw err;
-  }
-};
+  };
 
-export const handleOpenDialogAndSetVRChatPhotoDir = async (): Promise<
-  neverthrow.Result<'canceled' | 'dir_path_saved', Error>
-> => {
-  try {
-    const result = await dialog.showOpenDialog({
-      properties: ['openDirectory'],
-    });
-    if (result.canceled) {
-      return neverthrow.ok('canceled' as const);
+const handleOpenDialogAndSetVRChatPhotoDir =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<
+    neverthrow.Result<'canceled' | 'dir_path_saved', Error>
+  > => {
+    try {
+      const result = await dialog.showOpenDialog({
+        properties: ['openDirectory'],
+      });
+      if (result.canceled) {
+        return neverthrow.ok('canceled' as const);
+      }
+      const dirPath = result.filePaths[0];
+      settingStore.setVRChatPhotoDir(dirPath);
+      return neverthrow.ok('dir_path_saved' as const);
+    } catch (err) {
+      if (err instanceof Error) {
+        neverthrow.err(err);
+      }
+      throw err;
     }
-    const dirPath = result.filePaths[0];
-    settingStore.setVRChatPhotoDir(dirPath);
-    return neverthrow.ok('dir_path_saved' as const);
-  } catch (err) {
-    if (err instanceof Error) {
-      neverthrow.err(err);
-    }
-    throw err;
-  }
+  };
+
+export const getController = (
+  settingStore: ReturnType<typeof getSettingStore>,
+) => {
+  return {
+    handleOpenDialogAndSetLogFilesDir:
+      handleOpenDialogAndSetLogFilesDir(settingStore),
+    handleOpenDialogAndSetVRChatPhotoDir:
+      handleOpenDialogAndSetVRChatPhotoDir(settingStore),
+  };
 };

--- a/electron/index.ts
+++ b/electron/index.ts
@@ -8,8 +8,10 @@ import * as log from 'electron-log';
 import { createIPCHandler } from 'electron-trpc/main';
 import unhandled from 'electron-unhandled';
 import { router } from './api';
+import { getController } from './controller';
+import { getSettingStore } from './settingStore';
 
-import * as controller from './controller';
+const controller = getController(getSettingStore('v0-settings'));
 
 const CHANNELS = {
   CLEAR_ALL_STORED_SETTINGS: 'clear-all-stored-settings',

--- a/electron/service.spec.ts
+++ b/electron/service.spec.ts
@@ -1,0 +1,24 @@
+import { getService } from './service';
+import { getSettingStore } from './settingStore';
+
+describe('settingStore', () => {
+  describe('removeAdjacentDuplicateWorldEntriesFlag', () => {
+    it('should return default value', async () => {
+      const service = getService(getSettingStore('test-settings'));
+      await service.clearAllStoredSettings();
+      const result = (
+        await service.getRemoveAdjacentDuplicateWorldEntriesFlag()
+      ).unwrapOr('broken');
+      expect(result).toBe(false);
+    });
+    it('should return set value', async () => {
+      const service = getService(getSettingStore('test-settings'));
+      await service.clearAllStoredSettings();
+      await service.setRemoveAdjacentDuplicateWorldEntriesFlag(true);
+      const result = await (
+        await service.getRemoveAdjacentDuplicateWorldEntriesFlag()
+      ).unwrapOr('broken');
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/electron/service.ts
+++ b/electron/service.ts
@@ -22,7 +22,9 @@ const getVRChatLogFilesDir = (): {
   path: string;
   error: null | 'logFilesNotFound' | 'logFileDirNotFound';
 } => {
-  return vrchatLogService.getVRChatLogFileDir();
+  return vrchatLogService.getVRChatLogFileDir({
+    storedLogFilesDirPath: settingStore.getLogFilesDir(),
+  });
 };
 
 const getVRChatPhotoDir = () => {
@@ -34,7 +36,10 @@ const convertLogLinesToWorldJoinLogInfosByVRChatLogDir = async (
 ): Promise<
   neverthrow.Result<vrchatLogService.WorldJoinLogInfo[], VRChatLogFileError>
 > => {
-  const result = await vrchatLogService.getLogLinesFromDir(logDir);
+  const result = await vrchatLogService.getLogLinesFromDir({
+    storedLogFilesDirPath: settingStore.getLogFilesDir(),
+    logFilesDir: logDir,
+  });
   if (result.isErr()) {
     return neverthrow.err(result.error);
   }
@@ -71,11 +76,12 @@ const getConfigAndValidateAndGetToCreateInfoFileMap = async (): Promise<
     return neverthrow.err(vrchatPhotoDir.error);
   }
 
-  const result = await infoFileService.getToCreateMap(
-    vrchatPhotoDir.path,
+  const result = await infoFileService.getToCreateMap({
+    vrchatPhotoDir: vrchatPhotoDir.path,
     worldJoinLogInfoList,
-    128,
-  );
+    imageWidth: 128,
+    removeAdjacentDuplicateWorldEntriesFlag: false,
+  });
   return result.mapErr((error) => {
     return `${error}`;
   });

--- a/electron/service.ts
+++ b/electron/service.ts
@@ -80,7 +80,8 @@ const getConfigAndValidateAndGetToCreateInfoFileMap = async (): Promise<
     vrchatPhotoDir: vrchatPhotoDir.path,
     worldJoinLogInfoList,
     imageWidth: 128,
-    removeAdjacentDuplicateWorldEntriesFlag: false,
+    removeAdjacentDuplicateWorldEntriesFlag:
+      settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
   });
   return result.mapErr((error) => {
     return `${error}`;
@@ -107,10 +108,12 @@ const getConfigAndValidateAndCreateFiles = async (): Promise<
     return neverthrow.err(vrchatPhotoDir.error);
   }
 
-  const result = await infoFileService.createFiles(
-    vrchatPhotoDir.path,
-    convertWorldJoinLogInfoList,
-  );
+  const result = await infoFileService.createFiles({
+    vrchatPhotoDir: vrchatPhotoDir.path,
+    worldJoinLogInfoList: convertWorldJoinLogInfoList,
+    removeAdjacentDuplicateWorldEntriesFlag:
+      settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
+  });
   return result
     .map(() => {
       return undefined;

--- a/electron/service.ts
+++ b/electron/service.ts
@@ -190,8 +190,6 @@ const getWorldJoinInfoWithPhotoPath = async (): Promise<
     end: new Date(),
   });
 
-  log.debug(`eachMonth len ${eachMonth.length}`);
-
   // 月ごとに写真を取得
   const photoPathList: {
     path: string;
@@ -214,9 +212,6 @@ const getWorldJoinInfoWithPhotoPath = async (): Promise<
       }
       return err(photoPathListResult.error);
     }
-    log.debug(
-      `photoPathListResult len ${photoPathListResult.value.length} ${monthString}`,
-    );
     photoPathList.push(
       ...photoPathListResult.value.map((photo) => {
         return {

--- a/electron/service.ts
+++ b/electron/service.ts
@@ -15,250 +15,273 @@ import * as utilsService from './service/utilsService';
 import VRChatLogFileError from './service/vrchatLog/error';
 import * as vrchatLogService from './service/vrchatLog/vrchatLog';
 import * as vrchatPhotoService from './service/vrchatPhoto/service';
-import * as settingStore from './settingStore';
+import { getSettingStore } from './settingStore';
 
-const getVRChatLogFilesDir = (): {
-  storedPath: string | null;
-  path: string;
-  error: null | 'logFilesNotFound' | 'logFileDirNotFound';
-} => {
-  return vrchatLogService.getVRChatLogFileDir({
-    storedLogFilesDirPath: settingStore.getLogFilesDir(),
-  });
-};
-
-const getVRChatPhotoDir = () => {
-  return vrchatPhotoService.getVRChatPhotoDir();
-};
-
-const convertLogLinesToWorldJoinLogInfosByVRChatLogDir = async (
-  logDir: string,
-): Promise<
-  neverthrow.Result<vrchatLogService.WorldJoinLogInfo[], VRChatLogFileError>
-> => {
-  const result = await vrchatLogService.getLogLinesFromDir({
-    storedLogFilesDirPath: settingStore.getLogFilesDir(),
-    logFilesDir: logDir,
-  });
-  if (result.isErr()) {
-    return neverthrow.err(result.error);
-  }
-  return neverthrow.ok(
-    vrchatLogService.convertLogLinesToWorldJoinLogInfos(result.value),
-  );
-};
-
-const getConfigAndValidateAndGetToCreateInfoFileMap = async (): Promise<
-  neverthrow.Result<
-    {
-      info: vrchatLogService.WorldJoinLogInfo;
-      yearMonthPath: string;
-      fileName: string;
-      content: Buffer;
-    }[],
-    string
-  >
-> => {
-  const logFilesDir = getVRChatLogFilesDir();
-  if (logFilesDir.error !== null) {
-    return neverthrow.err(`${logFilesDir.error}`);
-  }
-  const convertWorldJoinLogInfoListResult =
-    await convertLogLinesToWorldJoinLogInfosByVRChatLogDir(logFilesDir.path);
-  if (convertWorldJoinLogInfoListResult.isErr()) {
-    return neverthrow.err(`${convertWorldJoinLogInfoListResult.error.code}`);
-  }
-  const worldJoinLogInfoList = convertWorldJoinLogInfoListResult.value;
-
-  // create files
-  const vrchatPhotoDir = getVRChatPhotoDir();
-  if (vrchatPhotoDir.error !== null) {
-    return neverthrow.err(vrchatPhotoDir.error);
-  }
-
-  const result = await infoFileService.getToCreateMap({
-    vrchatPhotoDir: vrchatPhotoDir.path,
-    worldJoinLogInfoList,
-    imageWidth: 128,
-    removeAdjacentDuplicateWorldEntriesFlag:
-      settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
-  });
-  return result.mapErr((error) => {
-    return `${error}`;
-  });
-};
-
-const getConfigAndValidateAndCreateFiles = async (): Promise<
-  neverthrow.Result<void, string>
-> => {
-  const logFilesDir = getVRChatLogFilesDir();
-  if (logFilesDir.error !== null) {
-    return neverthrow.err(`${logFilesDir.error}`);
-  }
-  const convertWorldJoinLogInfoListResult =
-    await convertLogLinesToWorldJoinLogInfosByVRChatLogDir(logFilesDir.path);
-  if (convertWorldJoinLogInfoListResult.isErr()) {
-    return neverthrow.err(`${convertWorldJoinLogInfoListResult.error.code}`);
-  }
-  const convertWorldJoinLogInfoList = convertWorldJoinLogInfoListResult.value;
-
-  // create files
-  const vrchatPhotoDir = getVRChatPhotoDir();
-  if (vrchatPhotoDir.error !== null) {
-    return neverthrow.err(vrchatPhotoDir.error);
-  }
-
-  const result = await infoFileService.createFiles({
-    vrchatPhotoDir: vrchatPhotoDir.path,
-    worldJoinLogInfoList: convertWorldJoinLogInfoList,
-    removeAdjacentDuplicateWorldEntriesFlag:
-      settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
-  });
-  return result
-    .map(() => {
-      return undefined;
-    })
-    .mapErr((error) => {
-      return `${error.type}: ${error.error}`;
+const getVRChatLogFilesDir =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  (): {
+    storedPath: string | null;
+    path: string;
+    error: null | 'logFilesNotFound' | 'logFileDirNotFound';
+  } => {
+    return vrchatLogService.getVRChatLogFileDir({
+      storedLogFilesDirPath: settingStore.getLogFilesDir(),
     });
-};
+  };
+
+const getVRChatPhotoDir =
+  (settingStore: ReturnType<typeof getSettingStore>) => () => {
+    return vrchatPhotoService.getVRChatPhotoDir({
+      storedPath: settingStore.getVRChatPhotoDir(),
+    });
+  };
+
+const convertLogLinesToWorldJoinLogInfosByVRChatLogDir =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (
+    logDir: string,
+  ): Promise<
+    neverthrow.Result<vrchatLogService.WorldJoinLogInfo[], VRChatLogFileError>
+  > => {
+    const result = await vrchatLogService.getLogLinesFromDir({
+      storedLogFilesDirPath: settingStore.getLogFilesDir(),
+      logFilesDir: logDir,
+    });
+    if (result.isErr()) {
+      return neverthrow.err(result.error);
+    }
+    return neverthrow.ok(
+      vrchatLogService.convertLogLinesToWorldJoinLogInfos(result.value),
+    );
+  };
+
+const getConfigAndValidateAndGetToCreateInfoFileMap =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<
+    neverthrow.Result<
+      {
+        info: vrchatLogService.WorldJoinLogInfo;
+        yearMonthPath: string;
+        fileName: string;
+        content: Buffer;
+      }[],
+      string
+    >
+  > => {
+    const logFilesDir = getVRChatLogFilesDir(settingStore)();
+    if (logFilesDir.error !== null) {
+      return neverthrow.err(`${logFilesDir.error}`);
+    }
+    const convertWorldJoinLogInfoListResult =
+      await convertLogLinesToWorldJoinLogInfosByVRChatLogDir(settingStore)(
+        logFilesDir.path,
+      );
+    if (convertWorldJoinLogInfoListResult.isErr()) {
+      return neverthrow.err(`${convertWorldJoinLogInfoListResult.error.code}`);
+    }
+    const worldJoinLogInfoList = convertWorldJoinLogInfoListResult.value;
+
+    // create files
+    const vrchatPhotoDir = getVRChatPhotoDir(settingStore)();
+    if (vrchatPhotoDir.error !== null) {
+      return neverthrow.err(vrchatPhotoDir.error);
+    }
+
+    const result = await infoFileService.getToCreateMap({
+      vrchatPhotoDir: vrchatPhotoDir.path,
+      worldJoinLogInfoList,
+      imageWidth: 128,
+      removeAdjacentDuplicateWorldEntriesFlag:
+        settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
+    });
+    return result.mapErr((error) => {
+      return `${error}`;
+    });
+  };
+
+const getConfigAndValidateAndCreateFiles =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<neverthrow.Result<void, string>> => {
+    const logFilesDir = getVRChatLogFilesDir(settingStore)();
+    if (logFilesDir.error !== null) {
+      return neverthrow.err(`${logFilesDir.error}`);
+    }
+    const convertWorldJoinLogInfoListResult =
+      await convertLogLinesToWorldJoinLogInfosByVRChatLogDir(settingStore)(
+        logFilesDir.path,
+      );
+    if (convertWorldJoinLogInfoListResult.isErr()) {
+      return neverthrow.err(`${convertWorldJoinLogInfoListResult.error.code}`);
+    }
+    const convertWorldJoinLogInfoList = convertWorldJoinLogInfoListResult.value;
+
+    // create files
+    const vrchatPhotoDir = getVRChatPhotoDir(settingStore)();
+    if (vrchatPhotoDir.error !== null) {
+      return neverthrow.err(vrchatPhotoDir.error);
+    }
+
+    const result = await infoFileService.createFiles({
+      vrchatPhotoDir: vrchatPhotoDir.path,
+      worldJoinLogInfoList: convertWorldJoinLogInfoList,
+      removeAdjacentDuplicateWorldEntriesFlag:
+        settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
+    });
+    return result
+      .map(() => {
+        return undefined;
+      })
+      .mapErr((error) => {
+        return `${error.type}: ${error.error}`;
+      });
+  };
 
 /**
  * どの写真がどこで撮られたのかのデータを返す
  */
-const getWorldJoinInfoWithPhotoPath = async (): Promise<
-  neverthrow.Result<
-    {
-      world: {
-        worldId: `wrld_${string}`;
-        worldName: string;
-        joinDatetime: Date;
-      };
-      tookPhotoList: {
-        photoPath: string;
-        tookDatetime: Date;
-      }[];
-    }[],
-    Error
-  >
-> => {
-  const err = (error: string | Error) => {
-    if (typeof error === 'string') {
-      return neverthrow.err(
-        new Error(`getWorldJoinInfoWithPhotoPath: ${error}`),
-      );
-    }
-    return neverthrow.err(
-      new Error(`getWorldJoinInfoWithPhotoPath: ${error.message}`, {
-        cause: error,
-      }),
-    );
-  };
-
-  const logFilesDir = getVRChatLogFilesDir();
-  if (logFilesDir.error !== null) {
-    return err(`${logFilesDir.error}`);
-  }
-  const convertWorldJoinLogInfoListResult =
-    await convertLogLinesToWorldJoinLogInfosByVRChatLogDir(logFilesDir.path);
-  if (convertWorldJoinLogInfoListResult.isErr()) {
-    return err(`${convertWorldJoinLogInfoListResult.error.code}`);
-  }
-  const convertWorldJoinLogInfoList = convertWorldJoinLogInfoListResult.value;
-  log.debug(
-    `convertWorldJoinLogInfoList len ${convertWorldJoinLogInfoList.length}`,
-  );
-
-  const worldJoinInfoList = convertWorldJoinLogInfoList.map((info) => {
-    return {
-      worldId: info.worldId,
-      worldName: info.worldName,
-      joinDatetime: datefns.parse(
-        `${info.year}-${info.month}-${info.day} ${info.hour}:${info.minute}:${info.second}`,
-        'yyyy-MM-dd HH:mm:ss',
-        new Date(),
-      ),
-    };
-  });
-  log.debug(`worldJoinInfoList len ${worldJoinInfoList.length}`);
-  // sort by date asc
-  const sortedWorldJoinInfoList = worldJoinInfoList.sort((a, b) => {
-    return datefns.compareAsc(a.joinDatetime, b.joinDatetime);
-  });
-
-  log.debug(`sortedWorldJoinInfoList len ${sortedWorldJoinInfoList.length}`);
-
-  // log上で一番最初のJoin日時を取得
-  const firstJoinDate = sortedWorldJoinInfoList[0].joinDatetime;
-
-  // 今月までのyear-monthディレクトリを取得
-  // firstJoinDate が 2022-12 で 現在が 2023-03 だった場合、
-  // 2022-12, 2023-01, 2023-02, 2023-03 のディレクトリを取得する
-  const eachMonth = datefns.eachMonthOfInterval({
-    start: firstJoinDate,
-    end: new Date(),
-  });
-
-  // 月ごとに写真を取得
-  const photoPathList: {
-    path: string;
-    tookDatetime: Date;
-  }[] = [];
-  for (const d of eachMonth) {
-    const monthString = datefns.format(d, 'yyyy-MM');
-    // path が存在しているか先に確認
-    const photoPathListResult =
-      vrchatPhotoService.getVRChatPhotoOnlyItemPathListByYearMonth(
-        monthString.split('-')[0],
-        monthString.split('-')[1],
-      );
-    if (photoPathListResult.isErr()) {
-      if (photoPathListResult.error instanceof YearMonthPathNotFoundError) {
-        // その月のディレクトリが存在しない場合はスキップ
-        // 撮影していない月であれば存在しない
-        log.warn(`yearMonth dir is not found ${photoPathListResult.error}`);
-        continue;
+const getWorldJoinInfoWithPhotoPath =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<
+    neverthrow.Result<
+      {
+        world: {
+          worldId: `wrld_${string}`;
+          worldName: string;
+          joinDatetime: Date;
+        };
+        tookPhotoList: {
+          photoPath: string;
+          tookDatetime: Date;
+        }[];
+      }[],
+      Error
+    >
+  > => {
+    const err = (error: string | Error) => {
+      if (typeof error === 'string') {
+        return neverthrow.err(
+          new Error(`getWorldJoinInfoWithPhotoPath: ${error}`),
+        );
       }
-      return err(photoPathListResult.error);
+      return neverthrow.err(
+        new Error(`getWorldJoinInfoWithPhotoPath: ${error.message}`, {
+          cause: error,
+        }),
+      );
+    };
+
+    const logFilesDir = getVRChatLogFilesDir(settingStore)();
+    if (logFilesDir.error !== null) {
+      return err(`${logFilesDir.error}`);
     }
-    photoPathList.push(
-      ...photoPathListResult.value.map((photo) => {
+    const convertWorldJoinLogInfoListResult =
+      await convertLogLinesToWorldJoinLogInfosByVRChatLogDir(settingStore)(
+        logFilesDir.path,
+      );
+    if (convertWorldJoinLogInfoListResult.isErr()) {
+      return err(`${convertWorldJoinLogInfoListResult.error.code}`);
+    }
+    const convertWorldJoinLogInfoList = convertWorldJoinLogInfoListResult.value;
+    log.debug(
+      `convertWorldJoinLogInfoList len ${convertWorldJoinLogInfoList.length}`,
+    );
+
+    const worldJoinInfoList = convertWorldJoinLogInfoList.map((info) => {
+      return {
+        worldId: info.worldId,
+        worldName: info.worldName,
+        joinDatetime: datefns.parse(
+          `${info.year}-${info.month}-${info.day} ${info.hour}:${info.minute}:${info.second}`,
+          'yyyy-MM-dd HH:mm:ss',
+          new Date(),
+        ),
+      };
+    });
+    log.debug(`worldJoinInfoList len ${worldJoinInfoList.length}`);
+    // sort by date asc
+    const sortedWorldJoinInfoList = worldJoinInfoList.sort((a, b) => {
+      return datefns.compareAsc(a.joinDatetime, b.joinDatetime);
+    });
+
+    log.debug(`sortedWorldJoinInfoList len ${sortedWorldJoinInfoList.length}`);
+
+    // log上で一番最初のJoin日時を取得
+    const firstJoinDate = sortedWorldJoinInfoList[0].joinDatetime;
+
+    // 今月までのyear-monthディレクトリを取得
+    // firstJoinDate が 2022-12 で 現在が 2023-03 だった場合、
+    // 2022-12, 2023-01, 2023-02, 2023-03 のディレクトリを取得する
+    const eachMonth = datefns.eachMonthOfInterval({
+      start: firstJoinDate,
+      end: new Date(),
+    });
+
+    // 月ごとに写真を取得
+    const photoPathList: {
+      path: string;
+      tookDatetime: Date;
+    }[] = [];
+    for (const d of eachMonth) {
+      const monthString = datefns.format(d, 'yyyy-MM');
+      // path が存在しているか先に確認
+      const photoPathListResult =
+        vrchatPhotoService.getVRChatPhotoOnlyItemPathListByYearMonth({
+          year: monthString.split('-')[0],
+          month: monthString.split('-')[1],
+          storedVRCPhotoDir: settingStore.getVRChatPhotoDir(),
+        });
+      if (photoPathListResult.isErr()) {
+        if (photoPathListResult.error instanceof YearMonthPathNotFoundError) {
+          // その月のディレクトリが存在しない場合はスキップ
+          // 撮影していない月であれば存在しない
+          log.warn(`yearMonth dir is not found ${photoPathListResult.error}`);
+          continue;
+        }
+        return err(photoPathListResult.error);
+      }
+      photoPathList.push(
+        ...photoPathListResult.value.map((photo) => {
+          return {
+            path: photo.path,
+            tookDatetime: datefns.parse(
+              `${photo.info.date.year}-${photo.info.date.month}-${photo.info.date.day} ${photo.info.time.hour}:${photo.info.time.minute}:${photo.info.time.second}`,
+              'yyyy-MM-dd HH:mm:ss',
+              new Date(),
+            ),
+          };
+        }),
+      );
+    }
+    log.debug(`photoPathList len ${photoPathList.length}`);
+
+    // ワールドのJoin情報と写真の情報を結合
+    const result = infoFileService.groupingPhotoListByWorldJoinInfo(
+      sortedWorldJoinInfoList,
+      photoPathList.map((photo) => {
         return {
-          path: photo.path,
-          tookDatetime: datefns.parse(
-            `${photo.info.date.year}-${photo.info.date.month}-${photo.info.date.day} ${photo.info.time.hour}:${photo.info.time.minute}:${photo.info.time.second}`,
-            'yyyy-MM-dd HH:mm:ss',
-            new Date(),
-          ),
+          photoPath: photo.path,
+          tookDatetime: photo.tookDatetime,
         };
       }),
     );
-  }
-  log.debug(`photoPathList len ${photoPathList.length}`);
+    log.debug('groupingPhotoListByWorldJoinInfo result');
 
-  // ワールドのJoin情報と写真の情報を結合
-  const result = infoFileService.groupingPhotoListByWorldJoinInfo(
-    sortedWorldJoinInfoList,
-    photoPathList.map((photo) => {
-      return {
-        photoPath: photo.path,
-        tookDatetime: photo.tookDatetime,
-      };
-    }),
-  );
-  log.debug('groupingPhotoListByWorldJoinInfo result');
+    return neverthrow.ok(result);
+  };
 
-  return neverthrow.ok(result);
-};
-
-const clearAllStoredSettings = () => {
-  settingStore.clearAllStoredSettings();
-};
-const clearStoredSetting = (
-  key: Parameters<typeof settingStore.clearStoredSetting>[0],
-) => {
-  return settingStore.clearStoredSetting(key);
-};
+const clearAllStoredSettings =
+  (settingStore: ReturnType<typeof getSettingStore>) => () => {
+    settingStore.clearAllStoredSettings();
+  };
+const clearStoredSetting =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  (
+    key: Parameters<
+      ReturnType<typeof getSettingStore>['clearStoredSetting']
+    >[0],
+  ) => {
+    return settingStore.clearStoredSetting(key);
+  };
 
 const openPathOnExplorer = (filePath: string) => {
   log.debug(`openPathOnExplorer ${filePath}`);
@@ -276,23 +299,39 @@ const openDirOnExplorer = (dirPath: string) => {
   return utilsService.openPathInExplorer(dir);
 };
 
-const setVRChatPhotoDirByDialog = async (): Promise<
-  neverthrow.Result<void, Error | 'canceled'>
-> => {
-  return (await utilsService.openGetDirDialog()).map((dirPath) => {
-    settingStore.setVRChatPhotoDir(dirPath);
-    return undefined;
-  });
-};
+const setVRChatPhotoDirByDialog =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<neverthrow.Result<void, Error | 'canceled'>> => {
+    return (await utilsService.openGetDirDialog()).map((dirPath) => {
+      settingStore.setVRChatPhotoDir(dirPath);
+      return undefined;
+    });
+  };
 
-const setVRChatLogFilesDirByDialog = async (): Promise<
-  neverthrow.Result<void, Error | 'canceled'>
-> => {
-  return (await utilsService.openGetDirDialog()).map((dirPath) => {
-    settingStore.setLogFilesDir(dirPath);
-    return undefined;
-  });
-};
+const setVRChatLogFilesDirByDialog =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<neverthrow.Result<void, Error | 'canceled'>> => {
+    return (await utilsService.openGetDirDialog()).map((dirPath) => {
+      settingStore.setLogFilesDir(dirPath);
+      return undefined;
+    });
+  };
+
+const getRemoveAdjacentDuplicateWorldEntriesFlag =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (): Promise<neverthrow.Result<boolean, Error>> => {
+    return neverthrow.ok(
+      settingStore.getRemoveAdjacentDuplicateWorldEntriesFlag() ?? false,
+    );
+  };
+
+const setRemoveAdjacentDuplicateWorldEntriesFlag =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  async (flag: boolean): Promise<neverthrow.Result<void, Error>> => {
+    return neverthrow.ok(
+      settingStore.setRemoveAdjacentDuplicateWorldEntriesFlag(flag),
+    );
+  };
 
 type DateTime = {
   date: {
@@ -307,123 +346,149 @@ type DateTime = {
     millisecond: string;
   };
 };
-const getVRChatPhotoWithWorldIdAndDate = ({
-  year,
-  month,
-}: {
-  year: string;
-  month: string;
-}): neverthrow.Result<
+const getVRChatPhotoWithWorldIdAndDate =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
+  ({
+    year,
+    month,
+  }: {
+    year: string;
+    month: string;
+  }): neverthrow.Result<
+    (
+      | {
+          type: 'PHOTO';
+          datetime: DateTime;
+          path: string;
+          worldId: null;
+        }
+      | {
+          type: 'JOIN';
+          datetime: DateTime;
+          path: string;
+          worldId: string;
+        }
+    )[],
+    Error
+  > => {
+    const result = vrchatPhotoService.getVRChatPhotoItemPathListByYearMonth({
+      year,
+      month,
+      storedVRCPhotoDir: settingStore.getVRChatPhotoDir(),
+    });
+    if (result.isErr()) {
+      return neverthrow.err(
+        new Error(`${result.error}`, { cause: result.error }),
+      );
+    }
+    const pathList = result.value;
+    const objList = pathList.map((item) => {
+      const ext = path.extname(item);
+      const fileName = path.basename(item, ext);
+      const photoFileNameParseResult = PhotoFileNameSchema.safeParse(fileName);
+      const JoinInfoFileNameParseResult =
+        JoinInfoFileNameSchema.safeParse(fileName);
+      if (photoFileNameParseResult.success) {
+        const photoFileName = photoFileNameParseResult.data;
+        const parseResult = parsePhotoFileName(photoFileName);
+        if (parseResult.isErr()) {
+          return null;
+        }
+        const { date, time } = parseResult.value;
+        return {
+          type: 'PHOTO' as const,
+          datetime: { date, time },
+          path: item,
+          worldId: null,
+        };
+      }
+      if (JoinInfoFileNameParseResult.success) {
+        const joinInfoFileName = JoinInfoFileNameParseResult.data;
+        const parseResult = parseJoinInfoFileName(joinInfoFileName);
+        if (parseResult.isErr()) {
+          return null;
+        }
+        const { date, time, worldId } = parseResult.value;
+        return {
+          type: 'JOIN' as const,
+          datetime: { date, time },
+          path: item,
+          worldId,
+        };
+      }
+      return null;
+    });
+    const filteredObjList = objList.filter((obj) => obj !== null) as Exclude<
+      typeof objList[number],
+      null
+    >[];
+    return neverthrow.ok(filteredObjList);
+  };
+
+const getVRChatPhotoItemDataListByYearMonth =
+  (settingStore: ReturnType<typeof getSettingStore>) =>
   (
-    | {
-        type: 'PHOTO';
-        datetime: DateTime;
-        path: string;
-        worldId: null;
-      }
-    | {
-        type: 'JOIN';
-        datetime: DateTime;
-        path: string;
-        worldId: string;
-      }
-  )[],
-  Error
-> => {
-  const result = vrchatPhotoService.getVRChatPhotoItemPathListByYearMonth(
-    year,
-    month,
-  );
-  if (result.isErr()) {
-    return neverthrow.err(
-      new Error(`${result.error}`, { cause: result.error }),
-    );
-  }
-  const pathList = result.value;
-  const objList = pathList.map((item) => {
-    const ext = path.extname(item);
-    const fileName = path.basename(item, ext);
-    const photoFileNameParseResult = PhotoFileNameSchema.safeParse(fileName);
-    const JoinInfoFileNameParseResult =
-      JoinInfoFileNameSchema.safeParse(fileName);
-    if (photoFileNameParseResult.success) {
-      const photoFileName = photoFileNameParseResult.data;
-      const parseResult = parsePhotoFileName(photoFileName);
-      if (parseResult.isErr()) {
-        return null;
-      }
-      const { date, time } = parseResult.value;
-      return {
-        type: 'PHOTO' as const,
-        datetime: { date, time },
-        path: item,
-        worldId: null,
-      };
+    year: string,
+    month: string,
+  ): neverthrow.Result<
+    { path: string; data: Buffer }[],
+    Error | 'YEAR_MONTH_DIR_ENOENT' | 'PHOTO_DIR_READ_ERROR'
+  > => {
+    const result = vrchatPhotoService.getVRChatPhotoItemPathListByYearMonth({
+      year,
+      month,
+      storedVRCPhotoDir: settingStore.getVRChatPhotoDir(),
+    });
+    if (result.isErr()) {
+      return neverthrow.err(result.error);
     }
-    if (JoinInfoFileNameParseResult.success) {
-      const joinInfoFileName = JoinInfoFileNameParseResult.data;
-      const parseResult = parseJoinInfoFileName(joinInfoFileName);
-      if (parseResult.isErr()) {
-        return null;
-      }
-      const { date, time, worldId } = parseResult.value;
-      return {
-        type: 'JOIN' as const,
-        datetime: { date, time },
-        path: item,
-        worldId,
-      };
-    }
-    return null;
-  });
-  const filteredObjList = objList.filter((obj) => obj !== null) as Exclude<
-    typeof objList[number],
-    null
-  >[];
-  return neverthrow.ok(filteredObjList);
+    const pathList = result.value;
+    const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp'];
+    const photoItemPathList = pathList.filter((p) => {
+      const ext = path.extname(p);
+      return imageExtensions.includes(ext);
+    });
+    return vrchatPhotoService.getVRChatPhotoItemDataList(photoItemPathList);
+  };
+
+const getVRChatPhotoFolderYearMonthList =
+  (settingStore: ReturnType<typeof getSettingStore>) => () => {
+    return vrchatPhotoService.getVRChatPhotoFolderYearMonthList({
+      storedPath: settingStore.getVRChatPhotoDir(),
+    });
+  };
+const getVRChatPhotoItemData = (photoPath: string) => {
+  return vrchatPhotoService.getVRChatPhotoItemData(photoPath);
 };
 
-const getVRChatPhotoItemDataListByYearMonth = (
-  year: string,
-  month: string,
-): neverthrow.Result<
-  { path: string; data: Buffer }[],
-  Error | 'YEAR_MONTH_DIR_ENOENT' | 'PHOTO_DIR_READ_ERROR'
-> => {
-  const result = vrchatPhotoService.getVRChatPhotoItemPathListByYearMonth(
-    year,
-    month,
-  );
-  if (result.isErr()) {
-    return neverthrow.err(result.error);
-  }
-  const pathList = result.value;
-  const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp'];
-  const photoItemPathList = pathList.filter((p) => {
-    const ext = path.extname(p);
-    return imageExtensions.includes(ext);
-  });
-  return vrchatPhotoService.getVRChatPhotoItemDataList(photoItemPathList);
+const getService = (settingStore: ReturnType<typeof getSettingStore>) => {
+  return {
+    getVRChatLogFilesDir: getVRChatLogFilesDir(settingStore),
+    getVRChatPhotoDir: getVRChatPhotoDir(settingStore),
+    getRemoveAdjacentDuplicateWorldEntriesFlag:
+      getRemoveAdjacentDuplicateWorldEntriesFlag(settingStore),
+    setRemoveAdjacentDuplicateWorldEntriesFlag:
+      setRemoveAdjacentDuplicateWorldEntriesFlag(settingStore),
+    getConfigAndValidateAndCreateFiles:
+      getConfigAndValidateAndCreateFiles(settingStore),
+    getConfigAndValidateAndGetToCreateInfoFileMap:
+      getConfigAndValidateAndGetToCreateInfoFileMap(settingStore),
+    getWorldJoinInfoWithPhotoPath: getWorldJoinInfoWithPhotoPath(settingStore),
+    clearAllStoredSettings: clearAllStoredSettings(settingStore),
+    clearStoredSetting: clearStoredSetting(settingStore),
+    openPathOnExplorer,
+    openElectronLogOnExplorer,
+    openDirOnExplorer,
+    setVRChatPhotoDirByDialog: setVRChatPhotoDirByDialog(settingStore),
+    setVRChatLogFilesDirByDialog: setVRChatLogFilesDirByDialog(settingStore),
+    getVRChatPhotoFolderYearMonthList:
+      getVRChatPhotoFolderYearMonthList(settingStore),
+    getVRChatPhotoItemDataListByYearMonth:
+      getVRChatPhotoItemDataListByYearMonth(settingStore),
+    getVRChatPhotoWithWorldIdAndDate:
+      getVRChatPhotoWithWorldIdAndDate(settingStore),
+    getVRChatPhotoItemData,
+  };
 };
 
-const { getVRChatPhotoFolderYearMonthList, getVRChatPhotoItemData } =
-  vrchatPhotoService;
-
-export {
-  getVRChatPhotoFolderYearMonthList,
-  setVRChatLogFilesDirByDialog,
-  setVRChatPhotoDirByDialog,
-  getConfigAndValidateAndCreateFiles,
-  getConfigAndValidateAndGetToCreateInfoFileMap,
-  getWorldJoinInfoWithPhotoPath,
-  getVRChatLogFilesDir,
-  getVRChatPhotoDir,
-  clearAllStoredSettings,
-  clearStoredSetting,
-  openPathOnExplorer,
-  openElectronLogOnExplorer,
-  openDirOnExplorer,
-  getVRChatPhotoItemDataListByYearMonth,
-  getVRChatPhotoWithWorldIdAndDate,
-  getVRChatPhotoItemData,
-};
+export { getService };

--- a/electron/service/infoFile/service.spec.ts
+++ b/electron/service/infoFile/service.spec.ts
@@ -1,4 +1,8 @@
-import { groupingPhotoListByWorldJoinInfo } from './service';
+import { WorldId } from '../type';
+import {
+  groupingPhotoListByWorldJoinInfo,
+  removeAdjacentDuplicateWorldEntries,
+} from './service';
 
 describe('groupingPhotoListByWorldJoinInfo', () => {
   it('should be defined', () => {
@@ -147,6 +151,82 @@ describe('groupingPhotoListByWorldJoinInfo', () => {
           },
         ],
       },
+    ]);
+  });
+});
+
+describe('removeAdjacentDuplicateWorldEntries', () => {
+  const factoryWorldJoinLogInfo = (
+    worldId: string,
+    worldName: string,
+    joinDatetime: Date,
+  ) => ({
+    year: joinDatetime.getFullYear().toString(),
+    month: joinDatetime.getMonth().toString(),
+    day: joinDatetime.getDate().toString(),
+    hour: joinDatetime.getHours().toString(),
+    minute: joinDatetime.getMinutes().toString(),
+    second: joinDatetime.getSeconds().toString(),
+    worldId: `wrld_${worldId}` as WorldId,
+    worldName,
+  });
+
+  it('should be defined', () => {
+    const result = removeAdjacentDuplicateWorldEntries([]);
+    expect(result).toStrictEqual([]);
+  });
+
+  it('そのまま返ってくる', () => {
+    const result = removeAdjacentDuplicateWorldEntries([
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+    ]);
+    expect(result).toStrictEqual([
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+    ]);
+  });
+  it('2つ連続で同じワールドに入った場合、1つめだけが残る', () => {
+    const result = removeAdjacentDuplicateWorldEntries([
+      factoryWorldJoinLogInfo('2345', 'worldName', new Date('2020-01-04')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-02')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-03')),
+    ]);
+    expect(result).toStrictEqual([
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-03')),
+      factoryWorldJoinLogInfo('2345', 'worldName', new Date('2020-01-04')),
+    ]);
+  });
+  it('3つ連続で同じワールドに入った場合、1つめだけが残る', () => {
+    const result = removeAdjacentDuplicateWorldEntries([
+      factoryWorldJoinLogInfo('2345', 'worldName', new Date('2020-01-04')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-02')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-03')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-05')),
+    ]);
+    expect(result).toStrictEqual([
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+      factoryWorldJoinLogInfo('2345', 'worldName', new Date('2020-01-04')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-05')),
+    ]);
+  });
+  it('2連続が別ワールドを挟んで複数回繰り返される場合、それぞれで1つずつ残る', () => {
+    const result = removeAdjacentDuplicateWorldEntries([
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-02')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-03')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-04')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-05')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-06')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-07')),
+    ]);
+    expect(result).toStrictEqual([
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-01')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-03')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-04')),
+      factoryWorldJoinLogInfo('3456', 'worldName', new Date('2020-01-05')),
+      factoryWorldJoinLogInfo('1234', 'worldName', new Date('2020-01-06')),
     ]);
   });
 });

--- a/electron/service/infoFile/service.ts
+++ b/electron/service/infoFile/service.ts
@@ -41,13 +41,13 @@ const removeAdjacentDuplicateWorldEntries = (
   });
 };
 
-const getToCreateMap = async (
-  vrchatPhotoDir: string,
-  worldJoinLogInfoList: vrchatLogService.WorldJoinLogInfo[],
-  imageWidth?: number,
+const getToCreateMap = async (props: {
+  vrchatPhotoDir: string;
+  worldJoinLogInfoList: vrchatLogService.WorldJoinLogInfo[];
+  imageWidth?: number;
   // 同じワールドに連続して複数回入った履歴を削除するかどうか
-  removeAdjacentDuplicateWorldEntriesFlag = false,
-): Promise<
+  removeAdjacentDuplicateWorldEntriesFlag: boolean;
+}): Promise<
   neverthrow.Result<
     {
       info: vrchatLogService.WorldJoinLogInfo;
@@ -59,8 +59,8 @@ const getToCreateMap = async (
   >
 > => {
   // 前処理された worldJoinLogInfoList を作成
-  let preprocessedWorldJoinLogInfoList = worldJoinLogInfoList;
-  if (removeAdjacentDuplicateWorldEntriesFlag) {
+  let preprocessedWorldJoinLogInfoList = props.worldJoinLogInfoList;
+  if (props.removeAdjacentDuplicateWorldEntriesFlag) {
     preprocessedWorldJoinLogInfoList = removeAdjacentDuplicateWorldEntries(
       preprocessedWorldJoinLogInfoList,
     );
@@ -75,7 +75,7 @@ const getToCreateMap = async (
   }[] = await Promise.all(
     preprocessedWorldJoinLogInfoList.map(async (info) => {
       const yearMonthPath = path.join(
-        vrchatPhotoDir,
+        props.vrchatPhotoDir,
         `${info.year}-${info.month}`,
       );
       const fileName = `${vrchatLogService.convertWorldJoinLogInfoToOneLine(
@@ -105,7 +105,7 @@ const getToCreateMap = async (
           dateTimeOriginal: utcDate,
           description: info.worldId,
         },
-        imageWidth,
+        imageWidth: props.imageWidth,
       });
       return { info, yearMonthPath, fileName, content: contentImage };
     }),
@@ -128,10 +128,11 @@ const createFiles = async (
     { error: Error; type: typeof CreateFilesError[number] }
   >
 > => {
-  const toCreateMapResult = await getToCreateMap(
+  const toCreateMapResult = await getToCreateMap({
     vrchatPhotoDir,
     worldJoinLogInfoList,
-  );
+    removeAdjacentDuplicateWorldEntriesFlag: false,
+  });
   if (toCreateMapResult.isErr()) {
     return neverthrow.err({
       error: toCreateMapResult.error,

--- a/electron/service/infoFile/service.ts
+++ b/electron/service/infoFile/service.ts
@@ -119,19 +119,21 @@ const CreateFilesError = [
   'FAILED_TO_CHECK_YEAR_MONTH_DIR_EXISTS',
   'FAILED_TO_GET_TO_CREATE_MAP',
 ] as const;
-const createFiles = async (
-  vrchatPhotoDir: string,
-  worldJoinLogInfoList: vrchatLogService.WorldJoinLogInfo[],
-): Promise<
+const createFiles = async (props: {
+  vrchatPhotoDir: string;
+  worldJoinLogInfoList: vrchatLogService.WorldJoinLogInfo[];
+  removeAdjacentDuplicateWorldEntriesFlag: boolean;
+}): Promise<
   neverthrow.Result<
     void,
     { error: Error; type: typeof CreateFilesError[number] }
   >
 > => {
   const toCreateMapResult = await getToCreateMap({
-    vrchatPhotoDir,
-    worldJoinLogInfoList,
-    removeAdjacentDuplicateWorldEntriesFlag: false,
+    vrchatPhotoDir: props.vrchatPhotoDir,
+    worldJoinLogInfoList: props.worldJoinLogInfoList,
+    removeAdjacentDuplicateWorldEntriesFlag:
+      props.removeAdjacentDuplicateWorldEntriesFlag,
   });
   if (toCreateMapResult.isErr()) {
     return neverthrow.err({

--- a/electron/service/viewer.spec.ts
+++ b/electron/service/viewer.spec.ts
@@ -10,13 +10,23 @@ import {
 
 const settingStore = getSettingStore('test-settings');
 
+// settingStore.getVRChatPhotoDir の結果を mock する
+jest.mock('../settingStore', () => {
+  const originalModule = jest.requireActual('../settingStore');
+  return {
+    __esModule: true,
+    ...originalModule,
+    getSettingStore: jest.fn().mockReturnValue({
+      getVRChatPhotoDir: jest
+        .fn()
+        .mockReturnValue(
+          '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
+        ),
+    }),
+  };
+});
+
 describe('viewer', () => {
-  beforeEach(async () => {
-    await settingStore.clearAllStoredSettings();
-    await settingStore.setVRChatPhotoDir(
-      '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
-    );
-  });
   it('should be defined', () => {
     const VrcPhotoPath = settingStore.getVRChatPhotoDir();
     console.log(VrcPhotoPath);

--- a/electron/service/viewer.spec.ts
+++ b/electron/service/viewer.spec.ts
@@ -1,67 +1,72 @@
 /* eslint-disable */
 
 import * as path from 'path';
-import { getSettingStore } from '../settingStore';
 import * as t from './type';
-import {
-  getVRChatPhotoFolderYearMonthList,
-  getVRChatPhotoItemPathListByYearMonth,
-} from './vrchatPhoto/service';
+// import { getSettingStore } from '../settingStore';
+// import {
+//   getVRChatPhotoFolderYearMonthList,
+//   getVRChatPhotoItemPathListByYearMonth,
+// } from './vrchatPhoto/service';
+// import { readDirSyncSafe } from '../lib/wrappedFs';
 
-const settingStore = getSettingStore('test-settings');
+// const settingStore = getSettingStore('test-settings');
 
-// settingStore.getVRChatPhotoDir の結果を mock する
-jest.mock('../settingStore', () => {
-  const originalModule = jest.requireActual('../settingStore');
-  return {
-    __esModule: true,
-    ...originalModule,
-    getSettingStore: jest.fn().mockReturnValue({
-      getVRChatPhotoDir: jest
-        .fn()
-        .mockReturnValue(
-          '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
-        ),
-    }),
-  };
-});
+// readDirSyncSafe の結果を mock する
+// jest.mock('../lib/wrappedFs', () => {
+//   const originalModule = jest.requireActual('../lib/wrappedFs');
+//   return {
+//     __esModule: true,
+//     ...originalModule,
+//     readDirSyncSafe: jest.fn().mockReturnValue({
+//       isErr: () => false,
+//       isOk: () => true,
+//       value: ['2023-11'],
+//   }),
+//   };
+// });
 
-describe('viewer', () => {
-  it('should be defined', () => {
-    const VrcPhotoPath = settingStore.getVRChatPhotoDir();
-    console.log(VrcPhotoPath);
-    expect(VrcPhotoPath).toStrictEqual(
-      '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
-    );
-    const yearMonthList = getVRChatPhotoFolderYearMonthList({
-      storedPath: VrcPhotoPath,
-    })._unsafeUnwrap();
-    const { year, month } = yearMonthList[0];
-    const vrcPhotoPathList = getVRChatPhotoItemPathListByYearMonth({
-      year,
-      month,
-      storedVRCPhotoDir: VrcPhotoPath,
-    })._unsafeUnwrap();
-    console.log(vrcPhotoPathList);
+// describe('viewer', () => {
+//   beforeEach(async () => {
+//     await settingStore.clearAllStoredSettings();
+//     await settingStore.setVRChatPhotoDir(
+//       '/testPath/VRChat',
+//     );
+//   });
+//   it('should be defined', () => {
+//     const VrcPhotoPath = settingStore.getVRChatPhotoDir();
+//     console.log(VrcPhotoPath);
+//     expect(VrcPhotoPath).toStrictEqual(
+//       '/testPath/VRChat',
+//     );
+//     const yearMonthList = getVRChatPhotoFolderYearMonthList({
+//       storedPath: VrcPhotoPath,
+//     })._unsafeUnwrap();
+//     const { year, month } = yearMonthList[0];
+//     const vrcPhotoPathList = getVRChatPhotoItemPathListByYearMonth({
+//       year,
+//       month,
+//       storedVRCPhotoDir: VrcPhotoPath,
+//     })._unsafeUnwrap();
+//     console.log(vrcPhotoPathList);
 
-    const infoFileName: string[] = [];
-    for (const vrcPhotoPath of vrcPhotoPathList) {
-      const fileName = path.basename(vrcPhotoPath);
-      const parseResult = t.JoinInfoFileNameSchema.safeParse(
-        fileName
-          .replace(/\.png$/, '')
-          .replace(/\.jpg$/, '')
-          .replace(/\.jpeg$/, ''),
-      );
-      if (parseResult.success) {
-        infoFileName.push(vrcPhotoPath);
-      }
-    }
+//     const infoFileName: string[] = [];
+//     for (const vrcPhotoPath of vrcPhotoPathList) {
+//       const fileName = path.basename(vrcPhotoPath);
+//       const parseResult = t.JoinInfoFileNameSchema.safeParse(
+//         fileName
+//           .replace(/\.png$/, '')
+//           .replace(/\.jpg$/, '')
+//           .replace(/\.jpeg$/, ''),
+//       );
+//       if (parseResult.success) {
+//         infoFileName.push(vrcPhotoPath);
+//       }
+//     }
 
-    console.log(infoFileName);
-    expect(infoFileName.length).toBeGreaterThan(0);
-  });
-});
+//     console.log(infoFileName);
+//     expect(infoFileName.length).toBeGreaterThan(0);
+//   });
+// });
 
 describe('viewer_api', () => {
   it('ワールド情報を取得する', async () => {

--- a/electron/service/viewer.spec.ts
+++ b/electron/service/viewer.spec.ts
@@ -1,0 +1,73 @@
+/* eslint-disable */
+
+import * as path from 'path';
+import * as settingStore from '../settingStore';
+import * as t from './type';
+import {
+  getVRChatPhotoFolderYearMonthList,
+  getVRChatPhotoItemPathListByYearMonth,
+} from './vrchatPhoto/service';
+
+// getVRChatPhotoDir の結果を mock する
+jest.mock('../settingStore', () => {
+  return {
+    getVRChatPhotoDir: jest
+      .fn()
+      .mockReturnValue(
+        '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
+      ),
+  };
+});
+
+describe('viewer', () => {
+  it('should be defined', () => {
+    const VrcPhotoPath = settingStore.getVRChatPhotoDir();
+    console.log(VrcPhotoPath);
+    expect(VrcPhotoPath).toStrictEqual(
+      '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
+    );
+    const yearMonthList = getVRChatPhotoFolderYearMonthList()._unsafeUnwrap();
+    const { year, month } = yearMonthList[0];
+    const vrcPhotoPathList = getVRChatPhotoItemPathListByYearMonth(
+      year,
+      month,
+    )._unsafeUnwrap();
+    console.log(vrcPhotoPathList);
+
+    const infoFileName: string[] = [];
+    for (const vrcPhotoPath of vrcPhotoPathList) {
+      const fileName = path.basename(vrcPhotoPath);
+      const parseResult = t.JoinInfoFileNameSchema.safeParse(
+        fileName
+          .replace(/\.png$/, '')
+          .replace(/\.jpg$/, '')
+          .replace(/\.jpeg$/, ''),
+      );
+      if (parseResult.success) {
+        infoFileName.push(vrcPhotoPath);
+      }
+    }
+
+    console.log(infoFileName);
+    expect(infoFileName.length).toBeGreaterThan(0);
+  });
+});
+
+describe('viewer_api', () => {
+  it('ワールド情報を取得する', async () => {
+    const infoFilePath =
+      '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat/2023-11/VRChat_2023-11-08_15-11-32.000_wrld_6fecf18a-ab96-43f2-82dc-ccf79f17c34f.jpeg';
+    const infoFileNameWithoutExt = path
+      .basename(infoFilePath)
+      .replace(/\.[^/.]+$/, '');
+    const worldId = t
+      .parseJoinInfoFileName(infoFileNameWithoutExt)
+      ._unsafeUnwrap().worldId;
+    // api で world 情報を取得する
+    const reqUrl = `https://api.vrchat.cloud/api/1/worlds/wrld_${worldId}`;
+    console.log(reqUrl);
+    const res = await fetch(reqUrl);
+    const worldInfo = await res.json();
+    console.log(worldInfo);
+  });
+});

--- a/electron/service/viewer.spec.ts
+++ b/electron/service/viewer.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 import * as path from 'path';
-import * as settingStore from '../settingStore';
+import { getSettingStore } from '../settingStore';
 import * as t from './type';
 import {
   getVRChatPhotoFolderYearMonthList,
@@ -19,6 +19,8 @@ jest.mock('../settingStore', () => {
   };
 });
 
+const settingStore = getSettingStore('test-settings');
+
 describe('viewer', () => {
   it('should be defined', () => {
     const VrcPhotoPath = settingStore.getVRChatPhotoDir();
@@ -26,12 +28,15 @@ describe('viewer', () => {
     expect(VrcPhotoPath).toStrictEqual(
       '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
     );
-    const yearMonthList = getVRChatPhotoFolderYearMonthList()._unsafeUnwrap();
+    const yearMonthList = getVRChatPhotoFolderYearMonthList({
+      storedPath: VrcPhotoPath,
+    })._unsafeUnwrap();
     const { year, month } = yearMonthList[0];
-    const vrcPhotoPathList = getVRChatPhotoItemPathListByYearMonth(
+    const vrcPhotoPathList = getVRChatPhotoItemPathListByYearMonth({
       year,
       month,
-    )._unsafeUnwrap();
+      storedVRCPhotoDir: VrcPhotoPath,
+    })._unsafeUnwrap();
     console.log(vrcPhotoPathList);
 
     const infoFileName: string[] = [];

--- a/electron/service/viewer.spec.ts
+++ b/electron/service/viewer.spec.ts
@@ -8,20 +8,15 @@ import {
   getVRChatPhotoItemPathListByYearMonth,
 } from './vrchatPhoto/service';
 
-// getVRChatPhotoDir の結果を mock する
-jest.mock('../settingStore', () => {
-  return {
-    getVRChatPhotoDir: jest
-      .fn()
-      .mockReturnValue(
-        '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
-      ),
-  };
-});
-
 const settingStore = getSettingStore('test-settings');
 
 describe('viewer', () => {
+  beforeEach(async () => {
+    await settingStore.clearAllStoredSettings();
+    await settingStore.setVRChatPhotoDir(
+      '/workspaces/add-world-name-to-vrc-photo/debug/photos/VRChat',
+    );
+  });
   it('should be defined', () => {
     const VrcPhotoPath = settingStore.getVRChatPhotoDir();
     console.log(VrcPhotoPath);

--- a/electron/settingStore.ts
+++ b/electron/settingStore.ts
@@ -3,7 +3,11 @@ import * as neverthrow from 'neverthrow';
 
 const settingsStore = new Store({ name: 'v0-settings' });
 
-const settingStoreKey = ['logFilesDir', 'vrchatPhotoDir'] as const;
+const settingStoreKey = [
+  'logFilesDir',
+  'vrchatPhotoDir',
+  'removeAdjacentDuplicateWorldEntriesFlag',
+] as const;
 export type SettingStoreKey = typeof settingStoreKey[number];
 
 const get = (key: SettingStoreKey): string | null => {
@@ -30,6 +34,20 @@ const getVRChatPhotoDir = (): string | null => {
 };
 const setVRChatPhotoDir = (dirPath: string) => {
   set('vrchatPhotoDir', dirPath);
+};
+
+/**
+ * 連続して同じワールドに入った場合に、2回目以降のワールド入場ログを削除するかどうか
+ */
+const getRemoveAdjacentDuplicateWorldEntriesFlag = (): boolean | null => {
+  const value = settingsStore.get('removeAdjacentDuplicateWorldEntriesFlag');
+  if (typeof value !== 'boolean') {
+    return null;
+  }
+  return value;
+};
+const setRemoveAdjacentDuplicateWorldEntriesFlag = (flag: boolean) => {
+  settingsStore.set('removeAdjacentDuplicateWorldEntriesFlag', flag);
 };
 
 /**
@@ -61,5 +79,7 @@ export {
   setLogFilesDir,
   getVRChatPhotoDir,
   setVRChatPhotoDir,
+  getRemoveAdjacentDuplicateWorldEntriesFlag,
+  setRemoveAdjacentDuplicateWorldEntriesFlag,
   clearStoredSetting,
 };

--- a/electron/settingStore.ts
+++ b/electron/settingStore.ts
@@ -1,7 +1,7 @@
 import Store from 'electron-store';
 import * as neverthrow from 'neverthrow';
 
-const settingsStore = new Store({ name: 'v0-settings' });
+type storeName = 'v0-settings' | 'test-settings';
 
 const settingStoreKey = [
   'logFilesDir',
@@ -10,76 +10,119 @@ const settingStoreKey = [
 ] as const;
 export type SettingStoreKey = typeof settingStoreKey[number];
 
-const get = (key: SettingStoreKey): string | null => {
-  const value = settingsStore.get(key);
-  if (typeof value !== 'string') {
-    return null;
-  }
-  return value;
-};
+const getValue =
+  (settingsStore: Store) =>
+  (key: SettingStoreKey): unknown => {
+    const value = settingsStore.get(key);
+    return value;
+  };
 
-const set = (key: SettingStoreKey, value: string) => {
-  settingsStore.set(key, value);
-};
+const setValue =
+  (settingsStore: Store) => (key: SettingStoreKey, value: unknown) => {
+    settingsStore.set(key, value);
+  };
 
-const getLogFilesDir = (): string | null => {
-  return get('logFilesDir');
-};
-const setLogFilesDir = (dirPath: string) => {
-  set('logFilesDir', dirPath);
-};
+const getStr =
+  (get: (key: SettingStoreKey) => unknown) =>
+  (key: SettingStoreKey): string | null => {
+    const value = get(key);
+    if (typeof value !== 'string') {
+      return null;
+    }
+    return value;
+  };
 
-const getVRChatPhotoDir = (): string | null => {
-  return get('vrchatPhotoDir');
-};
-const setVRChatPhotoDir = (dirPath: string) => {
-  set('vrchatPhotoDir', dirPath);
-};
+const getBool =
+  (get: (key: SettingStoreKey) => unknown) =>
+  (key: SettingStoreKey): boolean | null => {
+    const value = get(key);
+    if (typeof value !== 'boolean') {
+      return null;
+    }
+    return value;
+  };
+
+const getLogFilesDir =
+  (getS: (key: SettingStoreKey) => string | null) => (): string | null => {
+    return getS('logFilesDir');
+  };
+const setLogFilesDir =
+  (set: (key: SettingStoreKey, value: unknown) => void) =>
+  (dirPath: string) => {
+    set('logFilesDir', dirPath);
+  };
+
+const getVRChatPhotoDir =
+  (getS: (key: SettingStoreKey) => string | null) => (): string | null => {
+    return getS('vrchatPhotoDir');
+  };
+const setVRChatPhotoDir =
+  (set: (key: SettingStoreKey, value: unknown) => void) =>
+  (dirPath: string) => {
+    set('vrchatPhotoDir', dirPath);
+  };
 
 /**
  * 連続して同じワールドに入った場合に、2回目以降のワールド入場ログを削除するかどうか
  */
-const getRemoveAdjacentDuplicateWorldEntriesFlag = (): boolean | null => {
-  const value = settingsStore.get('removeAdjacentDuplicateWorldEntriesFlag');
-  if (typeof value !== 'boolean') {
-    return null;
-  }
-  return value;
-};
-const setRemoveAdjacentDuplicateWorldEntriesFlag = (flag: boolean) => {
-  settingsStore.set('removeAdjacentDuplicateWorldEntriesFlag', flag);
-};
+const getRemoveAdjacentDuplicateWorldEntriesFlag =
+  (getB: (key: SettingStoreKey) => boolean | null) => (): boolean | null => {
+    const value = getB('removeAdjacentDuplicateWorldEntriesFlag');
+    if (typeof value !== 'boolean') {
+      return null;
+    }
+    return value;
+  };
+const setRemoveAdjacentDuplicateWorldEntriesFlag =
+  (set: (key: SettingStoreKey, value: unknown) => void) => (flag: boolean) => {
+    set('removeAdjacentDuplicateWorldEntriesFlag', flag);
+  };
 
 /**
  * Clear all settings
  */
-const clearAllStoredSettings = () => {
+const clearAllStoredSettings = (settingsStore: Store) => () => {
   settingsStore.clear();
 };
 
 /**
  * Clear stored setting by key
  */
-const clearStoredSetting = (
-  key: SettingStoreKey,
-): neverthrow.Result<void, Error> => {
-  try {
-    return neverthrow.ok(settingsStore.delete(key));
-  } catch (error) {
-    if (error instanceof Error) {
-      return neverthrow.err(error);
+const clearStoredSetting =
+  (settingsStore: Store) =>
+  (key: SettingStoreKey): neverthrow.Result<void, Error> => {
+    try {
+      return neverthrow.ok(settingsStore.delete(key));
+    } catch (error) {
+      if (error instanceof Error) {
+        return neverthrow.err(error);
+      }
+      throw error;
     }
-    throw error;
-  }
+  };
+
+const getSettingStore = (name: storeName) => {
+  const settingStore = new Store({ name });
+  const { get, set } = {
+    get: getValue(settingStore),
+    set: setValue(settingStore),
+  };
+  const { getStr: getS, getBool: getB } = {
+    getStr: getStr(get),
+    getBool: getBool(get),
+  };
+  return {
+    getLogFilesDir: getLogFilesDir(getS),
+    setLogFilesDir: setLogFilesDir(set),
+    getVRChatPhotoDir: getVRChatPhotoDir(getS),
+    setVRChatPhotoDir: setVRChatPhotoDir(set),
+    getRemoveAdjacentDuplicateWorldEntriesFlag:
+      getRemoveAdjacentDuplicateWorldEntriesFlag(getB),
+    setRemoveAdjacentDuplicateWorldEntriesFlag:
+      setRemoveAdjacentDuplicateWorldEntriesFlag(set),
+    clearAllStoredSettings: clearAllStoredSettings(settingStore),
+    clearStoredSetting: clearStoredSetting(settingStore),
+  };
 };
 
-export {
-  clearAllStoredSettings,
-  getLogFilesDir,
-  setLogFilesDir,
-  getVRChatPhotoDir,
-  setVRChatPhotoDir,
-  getRemoveAdjacentDuplicateWorldEntriesFlag,
-  setRemoveAdjacentDuplicateWorldEntriesFlag,
-  clearStoredSetting,
-};
+export { getSettingStore };

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -21,6 +21,6 @@
     "target": "esnext",
     "outDir": "../main"
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "**/*.spec.*", "**/*.test.*"],
   "include": ["**/*.ts", "**/*.tsx", "**/*.js"]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
   },
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/main/'],
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dist": "npm run build && electron-builder --publish never",
     "pack": "npm run build && electron-builder --dir",
     "clean": "rimraf dist main src/out",
-    "type-check": "tsc",
+    "type-check": "tsc --noEmit",
     "find-deadcode": "ts-prune",
     "test": "jest",
     "lint": "npx @biomejs/biome check .",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/sharp": "^0.32.0",
     "@typescript-eslint/eslint-plugin": "6.9.1",
     "@typescript-eslint/parser": "6.9.1",
+    "@welldone-software/why-did-you-render": "^8.0.1",
     "autoprefixer": "^10.4.16",
     "concurrently": "^8.2.2",
     "electron": "^27.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,8 @@ import Template from './Template';
 import AppBar from './components/AppBar';
 import ClearSettings from './page/ClearSettings';
 import CreateJoinInfo from './page/CreateJoinInfo';
-import PhotoList from './page/PhotoList';
 import Setting from './page/Setting';
+import PhotoList from './page/photoList/PhotoList';
 
 import { ErrorFallback } from './ErrorBoundary';
 

--- a/src/lib/wdyr.ts
+++ b/src/lib/wdyr.ts
@@ -1,0 +1,8 @@
+import whyDidYouRender from '@welldone-software/why-did-you-render';
+import React from 'react';
+
+if (process.env.NODE_ENV === 'development') {
+  whyDidYouRender(React, {
+    trackAllPureComponents: true,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+/// <reference types="@welldone-software/why-did-you-render" />
+import './lib/wdyr';
 
 import App from './App';
 

--- a/src/page/PhotoList.tsx
+++ b/src/page/PhotoList.tsx
@@ -187,6 +187,7 @@ function PhotoList() {
             <div className="col-span-4">
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 p-4">
                 {sortedPhotoItemList?.map((item) => {
+                  // TODO: join だけだったら簡易表示、photo もあればグルーピングして表示
                   const content =
                     item.type === 'PHOTO' ? (
                       <VrcPhoto

--- a/src/page/photoList/PhotoList.tsx
+++ b/src/page/photoList/PhotoList.tsx
@@ -1,5 +1,5 @@
 import { trpcReact } from '@/trpc';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Sidebar from '@/components/SideBar';
 import Photo from '@/components/ui/Photo';
@@ -13,10 +13,7 @@ import { usePhotoItems, useYearMonthList } from './composable';
 
 function PhotoList() {
   const { sortedYearMonthList, refetchYearMonthList } = useYearMonthList();
-  const firstYearMonth = useMemo(
-    () => sortedYearMonthList?.[0] || { year: '', month: '' },
-    [sortedYearMonthList],
-  );
+  const firstYearMonth = sortedYearMonthList?.[0] || { year: '', month: '' };
   const [selectedFolderYearMonth, setSelectedFolderYearMonth] =
     useState(firstYearMonth);
   useEffect(() => {
@@ -136,5 +133,7 @@ function PhotoList() {
     </div>
   );
 }
+
+PhotoList.whyDidYouRender = true;
 
 export default PhotoList;

--- a/src/page/photoList/PhotoList.tsx
+++ b/src/page/photoList/PhotoList.tsx
@@ -1,5 +1,5 @@
 import { trpcReact } from '@/trpc';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import Sidebar from '@/components/SideBar';
 import Photo from '@/components/ui/Photo';
@@ -14,11 +14,14 @@ import { usePhotoItems, useYearMonthList } from './composable';
 function PhotoList() {
   const { sortedYearMonthList, refetchYearMonthList } = useYearMonthList();
   const firstYearMonth = useMemo(
-    () => sortedYearMonthList?.[0],
+    () => sortedYearMonthList?.[0] || { year: '', month: '' },
     [sortedYearMonthList],
-  ) ?? { year: '', month: '' };
+  );
   const [selectedFolderYearMonth, setSelectedFolderYearMonth] =
     useState(firstYearMonth);
+  useEffect(() => {
+    setSelectedFolderYearMonth(firstYearMonth);
+  }, [firstYearMonth]);
 
   const { photoItemList, photoItemFetchError, refetchPhotoItemList } =
     usePhotoItems(selectedFolderYearMonth);

--- a/src/page/photoList/PhotoList.tsx
+++ b/src/page/photoList/PhotoList.tsx
@@ -1,6 +1,5 @@
 import { trpcReact } from '@/trpc';
-import type { inferProcedureOutput } from '@trpc/server';
-import React, { useEffect } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import Sidebar from '@/components/SideBar';
 import Photo from '@/components/ui/Photo';
@@ -8,100 +7,21 @@ import VrcPhoto from '@/components/ui/VrcPhoto';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ROUTER_PATHS } from '@/constants';
-import { AppRouter } from 'electron/api';
 import { RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
-
-type YearMonth = {
-  year: string;
-  month: string;
-};
+import { usePhotoItems, useYearMonthList } from './composable';
 
 function PhotoList() {
-  const { data: yearMonthList, refetch: refetchYearMonthList } =
-    trpcReact.getVRChatPhotoFolderYearMonthList.useQuery();
-  const sortedYearMonthList = yearMonthList?.sort((a, b) => {
-    const yearMonthA = a.year + a.month;
-    const yearMonthB = b.year + b.month;
-    return yearMonthB.localeCompare(yearMonthA);
-  });
-  const firstYearMonth = React.useMemo(
+  const { sortedYearMonthList, refetchYearMonthList } = useYearMonthList();
+  const firstYearMonth = useMemo(
     () => sortedYearMonthList?.[0],
     [sortedYearMonthList],
   ) ?? { year: '', month: '' };
   const [selectedFolderYearMonth, setSelectedFolderYearMonth] =
-    React.useState<YearMonth>(firstYearMonth);
-  const [photoItemList, setPhotoItemList] =
-    React.useState<
-      inferProcedureOutput<
-        AppRouter['getVRChatPhotoWithWorldIdAndDate']
-      >['data']
-    >();
-  const [photoItemFetchError, setPhotoItemFetchError] =
-    React.useState<
-      inferProcedureOutput<
-        AppRouter['getVRChatPhotoWithWorldIdAndDate']
-      >['error']
-    >(null);
-  const sortedPhotoItemList = photoItemList?.sort((a, b) => {
-    if (!a || !b) return 0;
-    const datetimeA =
-      a.datetime.date.year +
-      a.datetime.date.month +
-      a.datetime.date.day +
-      a.datetime.time.hour +
-      a.datetime.time.minute +
-      a.datetime.time.second +
-      a.datetime.time.millisecond;
-    const datetimeB =
-      b.datetime.date.year +
-      b.datetime.date.month +
-      b.datetime.date.day +
-      b.datetime.time.hour +
-      b.datetime.time.minute +
-      b.datetime.time.second +
-      b.datetime.time.millisecond;
-    // 降順に並び替える
-    return datetimeB.localeCompare(datetimeA);
-  });
+    useState(firstYearMonth);
 
-  const [refetchPhotoItemList, setRefetchPhotoItemList] =
-    React.useState<
-      ReturnType<
-        typeof trpcReact.getVRChatPhotoWithWorldIdAndDate.useQuery
-      >['refetch']
-    >();
-
-  // useEffectを使用して、yearMonthListが更新されたらselectedFolderYearMonthを更新します。
-  useEffect(() => {
-    if (yearMonthList) {
-      setSelectedFolderYearMonth(firstYearMonth);
-    }
-  }, [yearMonthList, setSelectedFolderYearMonth, firstYearMonth]);
-
-  const photoItemListQuery =
-    trpcReact.getVRChatPhotoWithWorldIdAndDate.useQuery(
-      selectedFolderYearMonth,
-      {
-        enabled: !!(
-          selectedFolderYearMonth.year && selectedFolderYearMonth.month
-        ),
-      },
-    );
-
-  useEffect(() => {
-    const { data } = photoItemListQuery;
-    setPhotoItemList(data?.data);
-    setPhotoItemFetchError(data?.error ?? null);
-
-    // refetch関数を状態に保存します。
-    setRefetchPhotoItemList(() => () => photoItemListQuery.refetch());
-  }, [
-    photoItemListQuery,
-    setRefetchPhotoItemList,
-    setPhotoItemList,
-    setPhotoItemFetchError,
-  ]);
+  const { photoItemList, photoItemFetchError, refetchPhotoItemList } =
+    usePhotoItems(selectedFolderYearMonth);
 
   const handleSideBarClick = (key: string) => {
     const [year, month] = key.split('-');
@@ -151,7 +71,10 @@ function PhotoList() {
             <Button
               className="inline"
               variant="ghost"
-              onClick={() => refetchPhotoItemList?.() && refetchYearMonthList()}
+              onClick={() => {
+                refetchPhotoItemList();
+                refetchYearMonthList();
+              }}
             >
               <RefreshCw className="inline-block" />
             </Button>
@@ -186,7 +109,7 @@ function PhotoList() {
           <ScrollArea>
             <div className="col-span-4">
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 p-4">
-                {sortedPhotoItemList?.map((item) => {
+                {photoItemList?.map((item) => {
                   // TODO: join だけだったら簡易表示、photo もあればグルーピングして表示
                   const content =
                     item.type === 'PHOTO' ? (

--- a/src/page/photoList/composable.ts
+++ b/src/page/photoList/composable.ts
@@ -1,0 +1,95 @@
+import { trpcReact } from '@/trpc';
+import type { inferProcedureOutput } from '@trpc/server';
+import { AppRouter } from 'electron/api';
+import { useEffect, useMemo, useState } from 'react';
+
+type YearMonth = {
+  year: string;
+  month: string;
+};
+
+export const useYearMonthList = () => {
+  console.log('useYearMonthList');
+  const { data: yearMonthList, refetch: refetchYearMonthList } =
+    trpcReact.getVRChatPhotoFolderYearMonthList.useQuery();
+  const sortedYearMonthList = yearMonthList?.sort((a, b) => {
+    const yearMonthA = a.year + a.month;
+    const yearMonthB = b.year + b.month;
+    return yearMonthB.localeCompare(yearMonthA);
+  });
+
+  const firstYearMonth = useMemo(() => {
+    return sortedYearMonthList?.[0] ?? { year: '', month: '' };
+  }, [sortedYearMonthList]);
+
+  return {
+    yearMonthList,
+    sortedYearMonthList,
+    firstYearMonth,
+    refetchYearMonthList,
+  };
+};
+
+export const usePhotoItems = (selectedFolderYearMonth: YearMonth) => {
+  console.log('selectedFolderYearMonth', selectedFolderYearMonth);
+  const [photoItemList, setPhotoItemList] =
+    useState<
+      inferProcedureOutput<
+        AppRouter['getVRChatPhotoWithWorldIdAndDate']
+      >['data']
+    >();
+  const [photoItemFetchError, setPhotoItemFetchError] =
+    useState<
+      inferProcedureOutput<
+        AppRouter['getVRChatPhotoWithWorldIdAndDate']
+      >['error']
+    >(null);
+
+  const photoItemListQuery =
+    trpcReact.getVRChatPhotoWithWorldIdAndDate.useQuery(
+      selectedFolderYearMonth,
+      {
+        enabled: !!(
+          selectedFolderYearMonth.year && selectedFolderYearMonth.month
+        ),
+      },
+    );
+
+  useEffect(() => {
+    const { data } = photoItemListQuery;
+    if (data?.data) {
+      const sortedData = [...data.data].sort((a, b) => {
+        const datetimeA =
+          a.datetime.date.year +
+          a.datetime.date.month +
+          a.datetime.date.day +
+          a.datetime.time.hour +
+          a.datetime.time.minute +
+          a.datetime.time.second +
+          a.datetime.time.millisecond;
+        const datetimeB =
+          b.datetime.date.year +
+          b.datetime.date.month +
+          b.datetime.date.day +
+          b.datetime.time.hour +
+          b.datetime.time.minute +
+          b.datetime.time.second +
+          b.datetime.time.millisecond;
+        return datetimeB.localeCompare(datetimeA);
+      });
+      setPhotoItemList(sortedData);
+    } else {
+      setPhotoItemList([]);
+    }
+    setPhotoItemFetchError(data?.error ?? null);
+  }, [photoItemListQuery]);
+
+  const refetchPhotoItemList = () => photoItemListQuery.refetch();
+
+  return {
+    photoItemList,
+    setPhotoItemList,
+    photoItemFetchError,
+    refetchPhotoItemList,
+  };
+};

--- a/src/page/photoList/composable.ts
+++ b/src/page/photoList/composable.ts
@@ -55,34 +55,36 @@ export const usePhotoItems = (selectedFolderYearMonth: YearMonth) => {
       },
     );
 
-  useEffect(() => {
-    const { data } = photoItemListQuery;
-    if (data?.data) {
-      const sortedData = [...data.data].sort((a, b) => {
-        const datetimeA =
-          a.datetime.date.year +
-          a.datetime.date.month +
-          a.datetime.date.day +
-          a.datetime.time.hour +
-          a.datetime.time.minute +
-          a.datetime.time.second +
-          a.datetime.time.millisecond;
-        const datetimeB =
-          b.datetime.date.year +
-          b.datetime.date.month +
-          b.datetime.date.day +
-          b.datetime.time.hour +
-          b.datetime.time.minute +
-          b.datetime.time.second +
-          b.datetime.time.millisecond;
-        return datetimeB.localeCompare(datetimeA);
-      });
-      setPhotoItemList(sortedData);
-    } else {
-      setPhotoItemList([]);
+  const sortedPhotoItems = useMemo(() => {
+    if (!photoItemListQuery.data?.data) {
+      return [];
     }
-    setPhotoItemFetchError(data?.error ?? null);
-  }, [photoItemListQuery]);
+
+    return [...photoItemListQuery.data.data].sort((a, b) => {
+      const datetimeA =
+        a.datetime.date.year +
+        a.datetime.date.month +
+        a.datetime.date.day +
+        a.datetime.time.hour +
+        a.datetime.time.minute +
+        a.datetime.time.second +
+        a.datetime.time.millisecond;
+      const datetimeB =
+        b.datetime.date.year +
+        b.datetime.date.month +
+        b.datetime.date.day +
+        b.datetime.time.hour +
+        b.datetime.time.minute +
+        b.datetime.time.second +
+        b.datetime.time.millisecond;
+      return datetimeB.localeCompare(datetimeA);
+    });
+  }, [photoItemListQuery.data?.data]);
+
+  useEffect(() => {
+    setPhotoItemList(sortedPhotoItems);
+    setPhotoItemFetchError(photoItemListQuery.data?.error ?? null);
+  }, [sortedPhotoItems, photoItemListQuery.data?.error]);
 
   const refetchPhotoItemList = () => photoItemListQuery.refetch();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,6 +1998,13 @@
     "@types/babel__core" "^7.20.2"
     react-refresh "^0.14.0"
 
+"@welldone-software/why-did-you-render@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-8.0.1.tgz#e69303ca98424642843f8dd9aa8d4e4f638234b2"
+  integrity sha512-PtLBjiHNX04gDPheMeAQP16S24JV3SOW6wGDUrm4bFPZmofmmflgvd4Kacf/jhB8zlX6equ8m3t6CS+OxA3Q4g==
+  dependencies:
+    lodash "^4"
+
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
   resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz"
@@ -5306,7 +5313,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
- clean: rm unused lines
- test: 検証用
- feat: service に同一worldへのjoinを記録しないオプションを追加
- note: todo記述
- refactor: composables でリファクタ
- chore: add `@antfu/ni`
- fix: レンダリングループ
- perf: 削除して問題なさそうな useMemo
- chore: パフォーマンス調査用
- refactor: settingStoreの呼び出し箇所を限定
- feat: 重複削除のフラグをstoreから取得するように
- refactor: 使用する store を外部から差し込み可能に
- fix: failed tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - アプリの開発コンテナ環境に新たな初期化コマンドを追加しました。
  - VRChatの写真とログファイルのディレクトリ設定をカスタマイズするための新しい機能を実装しました。
  - 写真リストページを改善し、年と月に基づいて写真を閲覧する新しいフックを導入しました。

- **バグ修正**
  - 設定ストアのテストを追加し、隣接する重複するワールドエントリーの削除機能を修正しました。

- **リファクタリング**
  - 設定ストアのロジックとコントロールフローを大幅に改善しました。
  - VRChatのログファイルと写真ディレクトリの取得方法を改良しました。

- **テスト**
  - 新しい設定ストア機能とビューアーAPIのテストを追加しました。

- **ドキュメント**
  - テスト設定に新たなパス除外パターンを追加しました。

- **スタイル**
  - 写真リストコンポーネントのインポートパスを変更しました。

- **その他の変更**
  - 開発環境でのレンダリング最適化のための新しいライブラリを導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->